### PR TITLE
Fix duplicated protocol in nginx config

### DIFF
--- a/chapter10/router-dispatch/nginx.conf
+++ b/chapter10/router-dispatch/nginx.conf
@@ -3,7 +3,7 @@ http {
     listen       80;
     server_name  aofe.phodal.com;
     location /api/ {
-      proxy_pass http://http://172.31.25.15:8000/api;
+      proxy_pass http://172.31.25.15:8000/api;
     }
     location /web/admin {
       proxy_pass http://172.31.25.29/web/admin;


### PR DESCRIPTION
## Summary
- fix duplicated `http://` in `chapter10/router-dispatch/nginx.conf`

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6840fd647e14832fb9bfbc011a9e0ee8
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/mikey-wang/aofe.code/pull/1" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
